### PR TITLE
deps: detect & install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .DS_Store
 linux/
+dist/
 tczs/
 vmlinuz64
 corepure64.gz

--- a/README.md
+++ b/README.md
@@ -8,12 +8,16 @@ HyperCore is part of http://hyperos.io/
 
 ## build it
 
-```
-apt-get install squashfs-tools # brew install squashfs on mac
-npm i nugget -g  
+```sh
 ./download.sh
 ./build.sh
 ````
+
+## dependencies
+
+The following dependencies will be installed:
+- `unsquashfs` package to create an OS image
+- `nugget` package to pull data over the wire
 
 It should create `vmlinuz` (kernel) and `initrd.gz` (filesystem)
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
-# prerequisites: apt-get install squashfs-tools/brew install squashfs
+
+# install missing dependencies
+which unsquashfs > /dev/null
+if [ "$?" != 0 ]; then
+  printf 'Installing missing dependency: unsquashfs'
+  if [ "$(uname)" = "Darwin" ]; then
+    brew install squashfs
+  elif [ "$(uname)" = "Linux" ]; then
+    apt-get install squashfs-tools
+  fi
+  [ "$?" = 0 ] || { printf 'Could not install unsquashfs' && exit 1; }
+fi
+
+which nugget > /dev/null
+if [ "$?" != 0 ]; then
+  printf 'Installing missing dependency: nugget'
+  npm install -g nugget
+  [ "$?" = 0 ] || { printf 'Could not install nugget' && exit 1; }
+fi
 
 # exit on any error
 set -e


### PR DESCRIPTION
Rather than having to install dependencies manually this patch detects whether or not dependencies exist and installs them according to the platform (OS X/Debian). This might smoothen out the setup process a little.

Thanks!
